### PR TITLE
Identity providers are returned as an array

### DIFF
--- a/pkg/sac/client.go
+++ b/pkg/sac/client.go
@@ -108,14 +108,12 @@ func (c *Client) ListIdentityProviderIds(ctx context.Context) ([]string, error) 
 	q := url.Values{}
 	q.Set("includeLocal", "true")
 
-	var res struct {
-		IdPs []IdentityProvider
-	}
+	var res []IdentityProvider
 	if err := c.doRequest(ctx, providersUrl, &res, q); err != nil {
 		return nil, err
 	}
 
-	for _, identityProvider := range res.IdPs {
+	for _, identityProvider := range res {
 		providerIds = append(providerIds, identityProvider.ID)
 	}
 


### PR DESCRIPTION
So unmarshal directly in to an array.

https://api.luminate.io/#operation/ListIdentityProviders