### PR TITLE
Only set the page offset if we have a non-empty next page token

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/conductorone/baton-broadcom-sac/pkg/sac"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+
+	"github.com/conductorone/baton-broadcom-sac/pkg/sac"
 )
 
 type groupBuilder struct {
@@ -131,7 +132,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	}
 
 	if !paginationData.Last {
-		token, err = bag.NextToken(fmt.Sprintf("%v", paginationData.NextPage))
+		token, err = bag.NextToken(paginationData.NextPage)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/pkg/sac/client.go
+++ b/pkg/sac/client.go
@@ -102,9 +102,9 @@ func CreateBearerToken(ctx context.Context, username, password, tenant string) (
 	return res.AccessToken, nil
 }
 
-// ListIdentityProviderIds returns a list of identity provider ids.
-func (c *Client) ListIdentityProviderIds(ctx context.Context) ([]string, error) {
-	var providerIds []string
+// ListIdentityProviderIDs returns a list of identity provider ids.
+func (c *Client) ListIdentityProviderIDs(ctx context.Context) ([]string, error) {
+	var providerIDs []string
 	providersUrl := fmt.Sprintf("%s/identities/settings/identity-providers", c.baseUrl)
 
 	q := url.Values{}
@@ -116,10 +116,10 @@ func (c *Client) ListIdentityProviderIds(ctx context.Context) ([]string, error) 
 	}
 
 	for _, identityProvider := range res {
-		providerIds = append(providerIds, identityProvider.ID)
+		providerIDs = append(providerIDs, identityProvider.ID)
 	}
 
-	return providerIds, nil
+	return providerIDs, nil
 }
 
 // ListUserPerProvider returns a list of users for the given identity provider id.
@@ -145,7 +145,7 @@ func (c *Client) ListUsersPerProvider(ctx context.Context, identityProviderId st
 // ListAllUsers returns a list of all users for all identity providers.
 func (c *Client) ListAllUsers(ctx context.Context) ([]User, error) {
 	var allUsers []User
-	identityProviders, err := c.ListIdentityProviderIds(ctx)
+	identityProviders, err := c.ListIdentityProviderIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching identity providers: %w", err)
 	}
@@ -192,7 +192,7 @@ func (c *Client) ListGroupsPerProvider(ctx context.Context, identityProviderId s
 // ListAllGroups returns a list of all groups for all identity providers.
 func (c *Client) ListAllGroups(ctx context.Context) ([]Group, error) {
 	var allGroups []Group
-	identityProviders, err := c.ListIdentityProviderIds(ctx)
+	identityProviders, err := c.ListIdentityProviderIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching identity providers: %w", err)
 	}


### PR DESCRIPTION
The API docs say that the type of the next page token can be either a number or a string. I think it should be safe to always treat it as an opaque string since we are just using it as a query param. 