### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-broadcom-sac/main.go
+++ b/cmd/baton-broadcom-sac/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, cc *cfg.BroadcomSac) (types.ConnectorServ
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, cc.SacClientId, cc.SacClientSecret, cc.Tenant)
+	cb, err := connector.New(ctx, cc.SacClientId, cc.SacClientSecret, cc.Tenant, cc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type BroadcomSac struct {
 	SacClientId string `mapstructure:"sac-client-id"`
 	SacClientSecret string `mapstructure:"sac-client-secret"`
 	Tenant string `mapstructure:"tenant"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *BroadcomSac) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Broadcom SAC API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ var (
 		field.WithDescription("Override the Broadcom SAC API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,12 @@ var (
 		field.WithDisplayName("Tenant"),
 	)
 
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Broadcom SAC API URL (for testing)"),
+		field.WithDisplayName("Base URL"),
+	)
+
 	// FieldRelationships defines relationships between the fields listed in
 	// Config that can be automatically validated.
 	FieldRelationships = []field.SchemaFieldRelationship{}
@@ -39,6 +45,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	SacClientId,
 	SacClientSecret,
 	Tenant,
+	BaseURL,
 })
 
 // ValidateConfig is run after the configuration is loaded, and should return an

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,6 +18,7 @@ type Connector struct {
 	clientID     string
 	clientSecret string
 	tenant       string
+	baseURL      string
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
@@ -47,7 +48,7 @@ func (c *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 // Validate is called to ensure that the connector is properly configured. It should exercise any API credentials
 // to be sure that they are valid.
 func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, error) {
-	token, err := sac.CreateBearerToken(ctx, c.clientID, c.clientSecret, c.tenant)
+	token, err := sac.CreateBearerToken(ctx, c.clientID, c.clientSecret, c.tenant, c.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get access token: %w", err)
 	}
@@ -60,21 +61,22 @@ func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, clientID, clientSecret, tenant string) (*Connector, error) {
+func New(ctx context.Context, clientID, clientSecret, tenant, baseURL string) (*Connector, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := sac.CreateBearerToken(ctx, clientID, clientSecret, tenant)
+	token, err := sac.CreateBearerToken(ctx, clientID, clientSecret, tenant, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get access token: %w", err)
 	}
 
 	return &Connector{
-		client:       sac.NewClient(httpClient, tenant, token),
+		client:       sac.NewClient(httpClient, tenant, token, baseURL),
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		tenant:       tenant,
+		baseURL:      baseURL,
 	}, nil
 }

--- a/pkg/sac/client.go
+++ b/pkg/sac/client.go
@@ -17,11 +17,13 @@ type Client struct {
 	token      string
 }
 
-func NewClient(httpClient *http.Client, tenant, token string) *Client {
-	baseUrl := fmt.Sprintf("https://api.%s.luminatesec.com/v2", tenant)
+func NewClient(httpClient *http.Client, tenant, token, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://api.%s.luminatesec.com/v2", tenant)
+	}
 	return &Client{
 		httpClient: httpClient,
-		baseUrl:    baseUrl,
+		baseUrl:    baseURL,
 		token:      token,
 	}
 }
@@ -67,14 +69,17 @@ func paginationQueryPages(pageNumber int) url.Values {
 }
 
 // CreateBearerToken creates a bearer token for the given username, password, and tenant.
-func CreateBearerToken(ctx context.Context, username, password, tenant string) (string, error) {
+func CreateBearerToken(ctx context.Context, username, password, tenant, baseURL string) (string, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return "", err
 	}
 
-	url := fmt.Sprintf("https://api.%s.luminatesec.com/v1/oauth/token", tenant)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	tokenURL := baseURL
+	if tokenURL == "" {
+		tokenURL = fmt.Sprintf("https://api.%s.luminatesec.com/v1/oauth/token", tenant)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sac/client.go
+++ b/pkg/sac/client.go
@@ -75,8 +75,10 @@ func CreateBearerToken(ctx context.Context, username, password, tenant, baseURL 
 		return "", err
 	}
 
-	tokenURL := baseURL
-	if tokenURL == "" {
+	var tokenURL string
+	if baseURL != "" {
+		tokenURL = baseURL + "/v1/oauth/token"
+	} else {
 		tokenURL = fmt.Sprintf("https://api.%s.luminatesec.com/v1/oauth/token", tenant)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, nil)

--- a/pkg/sac/client.go
+++ b/pkg/sac/client.go
@@ -29,6 +29,7 @@ func NewClient(httpClient *http.Client, tenant, token, baseURL string) *Client {
 }
 
 type AuthResponse struct {
+	//nolint:gosec,nolintlint // G117: legitimate field name, not a credential
 	AccessToken      string `json:"access_token"`
 	ExpiresIn        int    `json:"expires_in"`
 	Scope            string `json:"scope"`
@@ -90,7 +91,7 @@ func CreateBearerToken(ctx context.Context, username, password, tenant, baseURL 
 	req.Header.Add("Content-Type", applicationJSONHeader)
 	req.SetBasicAuth(username, password)
 
-	resp, err := httpClient.Do(req)
+	resp, err := httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return "", err
 	}
@@ -296,7 +297,7 @@ func (c *Client) doRequest(ctx context.Context, url string, res interface{}, que
 
 	req.Header.Add("Accept", applicationJSONHeader)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-broadcom-sac/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/sac/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-broadcom-sac --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Base URL" configuration option that allows you to customize the Broadcom SAC API endpoint. This gives you flexibility to connect to alternative service instances, custom deployments, or different environments while preserving backward compatibility with existing configurations that use the default endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->