### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Broadcom SAC connector"
-description: "C1 provides identity governance and just-in-time provisioning for Broadcom SAC. Integrate your Broadcom SAC instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Broadcom SAC. Integrate your Broadcom SAC instance with C1 for unified visibility and governance over user access."
 og:title: "Set up a Broadcom SAC connector"
-og:description: "C1 provides identity governance and just-in-time provisioning for Broadcom SAC. Integrate your Broadcom SAC instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance for Broadcom SAC. Integrate your Broadcom SAC instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Broadcom SAC"
 ---
 
@@ -46,7 +46,7 @@ A user with administrative privileges in the Broadcom SAC tenant must perform th
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Broadcom SAC connector
 
@@ -99,7 +99,7 @@ A user with administrative privileges in the Broadcom SAC tenant must perform th
     </Step>
 </Steps>
 
-**That's it!** Your Broadcom SAC connector is now pulling access data into C1.
+**Done.** Your Broadcom SAC connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Broadcom SAC connector, hosted and run in your own environment.**
@@ -212,7 +212,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Broadcom SAC connector is now pulling access data into C1.
+**Done.** Your Broadcom SAC connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines