### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -32,13 +32,14 @@ func baseGroupResource(entity *sac.DirectoryEntity, parentResourceID *v2.Resourc
 		"provider_id": entity.IdentityProviderID,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{rs.WithGroupProfile(profile)}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		entity.DisplayName,
 		groupResourceType,
 		entity.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
@@ -55,13 +56,14 @@ func groupResource(group *sac.Group, parentResourceID *v2.ResourceId) (*v2.Resou
 		"provider_id": group.IdentityProviderID,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{rs.WithGroupProfile(profile)}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		group.Name,
 		groupResourceType,
 		group.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
@@ -116,12 +118,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 		return nil, "", nil, err
 	}
 
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	identityProviderId, ok := rs.GetProfileStringValue(groupTrait.Profile, "provider_id")
+	identityProviderId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "provider_id")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("error fetching provider_id from group profile")
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -38,15 +38,14 @@ func baseUserResource(entity *sac.DirectoryEntity, parentResourceID *v2.Resource
 		"identity_provider": entity.IdentityProviderType,
 	}
 
-	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-	}
+	userTraitOptions := []rs.UserTraitOption{}
 
 	ret, err := rs.NewUserResource(
 		entity.DisplayName,
 		userResourceType,
 		entity.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 
@@ -77,9 +76,7 @@ func userResource(user *sac.User, parentResourceID *v2.ResourceId) (*v2.Resource
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(user.Email, true),
-		rs.WithStatus(userStatus),
 	}
 
 	ret, err := rs.NewUserResource(
@@ -87,6 +84,8 @@ func userResource(user *sac.User, parentResourceID *v2.ResourceId) (*v2.Resource
 		userResourceType,
 		user.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
